### PR TITLE
Validate supported options and update docs

### DIFF
--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -3,24 +3,87 @@ defmodule BroadwayRabbitmq.AmqpClientTest do
 
   alias BroadwayRabbitmq.AmqpClient
 
-  describe "validate init options" do
-    test ":queue_name is required" do
-      assert AmqpClient.init([]) ==
-               {:error, "expected :queue_name to be a non empty string, got: nil"}
+  test "default options" do
+    assert AmqpClient.init(queue: "queue") ==
+             {:ok, "queue", %{connection: [], declare: [], qos: [prefetch_count: 50]}}
+  end
 
-      assert AmqpClient.init(queue_name: nil) ==
-               {:error, "expected :queue_name to be a non empty string, got: nil"}
+  describe "validate init options" do
+    test "supported options" do
+      connection = [
+        username: nil,
+        password: nil,
+        virtual_host: nil,
+        host: nil,
+        port: nil,
+        channel_max: nil,
+        frame_max: nil,
+        heartbeat: nil,
+        connection_timeout: nil,
+        ssl_options: nil,
+        client_properties: nil,
+        socket_options: nil
+      ]
+
+      declare = [
+        durable: nil,
+        auto_delete: nil,
+        exclusive: nil,
+        passive: nil
+      ]
+
+      qos = [
+        prefetch_size: nil,
+        prefetch_count: nil
+      ]
+
+      options = [
+        queue: "queue",
+        connection: connection,
+        declare: declare,
+        qos: qos
+      ]
+
+      assert AmqpClient.init(options) ==
+               {:ok, "queue", %{connection: connection, declare: declare, qos: qos}}
     end
 
-    test ":queue_name should be a non empty string" do
-      assert AmqpClient.init(queue_name: "") ==
-               {:error, "expected :queue_name to be a non empty string, got: \"\""}
+    test "unsupported options for Broadway" do
+      assert AmqpClient.init(queue: "queue", option_1: 1, option_2: 2) ==
+               {:error, "Unsupported options [:option_1, :option_2] for \"Broadway\""}
+    end
 
-      assert AmqpClient.init(queue_name: :an_atom) ==
-               {:error, "expected :queue_name to be a non empty string, got: :an_atom"}
+    test "unsupported options for :connection" do
+      assert AmqpClient.init(queue: "queue", connection: [option_1: 1, option_2: 2]) ==
+               {:error, "Unsupported options [:option_1, :option_2] for :connection"}
+    end
 
-      {:ok, queue_name, _} = AmqpClient.init(queue_name: "my_queue")
-      assert queue_name == "my_queue"
+    test "unsupported options for :declare" do
+      assert AmqpClient.init(queue: "queue", declare: [option_1: 1, option_2: 2]) ==
+               {:error, "Unsupported options [:option_1, :option_2] for :declare"}
+    end
+
+    test "unsupported options for :qos" do
+      assert AmqpClient.init(queue: "queue", qos: [option_1: 1, option_2: 2]) ==
+               {:error, "Unsupported options [:option_1, :option_2] for :qos"}
+    end
+
+    test ":queue is required" do
+      assert AmqpClient.init([]) == {:error, "expected :queue to be a non empty string, got: nil"}
+
+      assert AmqpClient.init(queue: nil) ==
+               {:error, "expected :queue to be a non empty string, got: nil"}
+    end
+
+    test ":queue should be a non empty string" do
+      assert AmqpClient.init(queue: "") ==
+               {:error, "expected :queue to be a non empty string, got: \"\""}
+
+      assert AmqpClient.init(queue: :an_atom) ==
+               {:error, "expected :queue to be a non empty string, got: :an_atom"}
+
+      {:ok, queue, _} = AmqpClient.init(queue: "my_queue")
+      assert queue == "my_queue"
     end
   end
 end

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -33,11 +33,11 @@ defmodule BroadwayRabbitmq.ProducerTest do
 
     @impl true
     def init(opts) do
-      {:ok, opts[:queue_name], opts}
+      {:ok, opts[:queue], opts}
     end
 
     @impl true
-    def setup_channel(_queue_name, config) do
+    def setup_channel(_queue, config) do
       test_pid = config[:test_pid]
 
       status =
@@ -72,7 +72,7 @@ defmodule BroadwayRabbitmq.ProducerTest do
     end
 
     @impl true
-    def consume(_channel, _queue_name) do
+    def consume(_channel, _queue) do
       :fake_consumer_tag
     end
 
@@ -127,9 +127,9 @@ defmodule BroadwayRabbitmq.ProducerTest do
   test "raise an ArgumentError with proper message when client options are invalid" do
     assert_raise(
       ArgumentError,
-      "invalid options given to BroadwayRabbitmq.AmqpClient.init/1, expected :queue_name to be a non empty string, got: nil",
+      "invalid options given to BroadwayRabbitmq.AmqpClient.init/1, expected :queue to be a non empty string, got: nil",
       fn ->
-        BroadwayRabbitmq.Producer.init(queue_name: nil)
+        BroadwayRabbitmq.Producer.init(queue: nil)
       end
     )
   end
@@ -139,19 +139,14 @@ defmodule BroadwayRabbitmq.ProducerTest do
       ArgumentError,
       "unknown type :unknown_type",
       fn ->
-        BroadwayRabbitmq.Producer.init(queue_name: "test", backoff_type: :unknown_type)
+        BroadwayRabbitmq.Producer.init(queue: "test", backoff_type: :unknown_type)
       end
     )
   end
 
-  test "defaut :prefetch_count is 50" do
-    {:producer, state, _} = BroadwayRabbitmq.Producer.init(queue_name: "test")
-    assert state[:config][:qos][:prefetch_count] == 50
-  end
-
   test "producer :buffer_size is :prefetch_count * 5" do
     qos = [prefetch_count: 12]
-    {:producer, _, options} = BroadwayRabbitmq.Producer.init(queue_name: "test", qos: qos)
+    {:producer, _, options} = BroadwayRabbitmq.Producer.init(queue: "test", qos: qos)
 
     assert options[:buffer_size] == 60
   end


### PR DESCRIPTION
  * It doesn't actually validates RabbitMQ options since they will be validated by the amqp client. What it does is to make sure unsupported options are not accepted.
  * Documentation does not list all RabbitMQ options avaiable. Instead it points to the amqp client documentation where all options are described

Closes #1 and #4
