### PR TITLE
Remove declare options

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -13,9 +13,6 @@ defmodule BroadwayRabbitmq.Producer do
     * `:connection` - Optional. Defines a set of options used by the RabbitMQ
       client to open the connection with the RabbitMQ broker. See
       `AMQP.Connection.open/1` for the full list of options.
-    * `:declare` - Optional. Defines a set of options used by the RabbitMQ
-      client to declare the queue. See `AMQP.Queue.declare/3` for the full list of
-      options.
     * `:qos` - Optional. Defines a set of prefetch options used by the RabbitMQ client.
       See `AMQP.Basic.qos/2` for the full list of options. Pay attention that the
       `:global` option is not supported by Broadway since each producer holds only one
@@ -40,13 +37,6 @@ defmodule BroadwayRabbitmq.Producer do
                 password: "password",
                 host: "192.168.0.10"
               ],
-              declare: [
-                durable: true,
-                arguments: [
-                  {"x-dead-letter-exchange", :longstr, ""},
-                  {"x-dead-letter-routing-key", :longstr, "my_queue_error"}
-                ]
-              ]
               qos: [
                 prefetch_count: 50
               ]},
@@ -228,7 +218,7 @@ defmodule BroadwayRabbitmq.Producer do
   defp connect(state) do
     %{client: client, queue_name: queue_name, config: config, backoff: backoff} = state
     # TODO: Treat other setup errors properly
-    case client.setup_channel(queue_name, config) do
+    case client.setup_channel(config) do
       {:ok, channel} ->
         ref = Process.monitor(channel.conn.pid)
         backoff = backoff && Backoff.reset(backoff)

--- a/lib/broadway_rabbitmq/rabbitmq_client.ex
+++ b/lib/broadway_rabbitmq/rabbitmq_client.ex
@@ -5,12 +5,11 @@ defmodule BroadwayRabbitmq.RabbitmqClient do
 
   @typep config :: %{
            connection: keyword,
-           declare: keyword,
            qos: keyword
          }
 
   @callback init(opts :: any) :: {:ok, queue_name :: String.t(), config} | {:error, any}
-  @callback setup_channel(queue_name :: String.t(), config) :: {:ok, Channel.t()} | {:error, any}
+  @callback setup_channel(config) :: {:ok, Channel.t()} | {:error, any}
   @callback ack(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag()) :: any
   @callback reject(channel :: Channel.t(), delivery_tag :: Basic.delivery_tag()) :: any
   @callback consume(channel :: Channel.t(), queue_name :: Basic.queue()) :: Basic.consumer_tag()

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule BroadwayRabbitmq.MixProject do
   defp deps do
     [
       {:broadway, git: "https://github.com/plataformatec/broadway.git"},
-      {:amqp, "~> 1.0"},
+      {:amqp, "~> 1.1"},
       {:ex_doc, ">= 0.19.0", only: :docs}
     ]
   end

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -5,7 +5,7 @@ defmodule BroadwayRabbitmq.AmqpClientTest do
 
   test "default options" do
     assert AmqpClient.init(queue: "queue") ==
-             {:ok, "queue", %{connection: [], declare: [], qos: [prefetch_count: 50]}}
+             {:ok, "queue", %{connection: [], qos: [prefetch_count: 50]}}
   end
 
   describe "validate init options" do
@@ -25,13 +25,6 @@ defmodule BroadwayRabbitmq.AmqpClientTest do
         socket_options: nil
       ]
 
-      declare = [
-        durable: nil,
-        auto_delete: nil,
-        exclusive: nil,
-        passive: nil
-      ]
-
       qos = [
         prefetch_size: nil,
         prefetch_count: nil
@@ -40,12 +33,10 @@ defmodule BroadwayRabbitmq.AmqpClientTest do
       options = [
         queue: "queue",
         connection: connection,
-        declare: declare,
         qos: qos
       ]
 
-      assert AmqpClient.init(options) ==
-               {:ok, "queue", %{connection: connection, declare: declare, qos: qos}}
+      assert AmqpClient.init(options) == {:ok, "queue", %{connection: connection, qos: qos}}
     end
 
     test "unsupported options for Broadway" do
@@ -56,11 +47,6 @@ defmodule BroadwayRabbitmq.AmqpClientTest do
     test "unsupported options for :connection" do
       assert AmqpClient.init(queue: "queue", connection: [option_1: 1, option_2: 2]) ==
                {:error, "Unsupported options [:option_1, :option_2] for :connection"}
-    end
-
-    test "unsupported options for :declare" do
-      assert AmqpClient.init(queue: "queue", declare: [option_1: 1, option_2: 2]) ==
-               {:error, "Unsupported options [:option_1, :option_2] for :declare"}
     end
 
     test "unsupported options for :qos" do

--- a/test/broadway_rabbitmq/producer_test.exs
+++ b/test/broadway_rabbitmq/producer_test.exs
@@ -37,7 +37,7 @@ defmodule BroadwayRabbitmq.ProducerTest do
     end
 
     @impl true
-    def setup_channel(_queue, config) do
+    def setup_channel(config) do
       test_pid = config[:test_pid]
 
       status =


### PR DESCRIPTION
  * Remove options
  * Don't call `Queue.declare/3`
  * Let it crash if the queue doesn't exist

Closes #13 