### PR TITLE
Allow for uris

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -144,8 +144,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     |> validate_supported_opts(group, supported)
   end
 
-  defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts)
-       when is_binary(uri) do
+  defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts) do
     {:ok, uri}
   end
 

--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -144,6 +144,10 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     |> validate_supported_opts(group, supported)
   end
 
+  defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts) when is_binary(uri) do
+   {:ok, uri}
+  end
+
   defp validate_supported_opts(opts, group_name, supported_opts) do
     opts
     |> Keyword.keys()

--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -144,8 +144,9 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     |> validate_supported_opts(group, supported)
   end
 
-  defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts) when is_binary(uri) do
-   {:ok, uri}
+  defp validate_supported_opts("amqp" <> _ = uri, :connection, _supported_opts)
+       when is_binary(uri) do
+    {:ok, uri}
   end
 
   defp validate_supported_opts(opts, group_name, supported_opts) do

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -45,6 +45,13 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                 %{connection: connection, qos: qos, requeue: :once, metadata: metadata}}
     end
 
+    test "configure connection via uri" do
+      connection = "amqp://guest:guest@127.0.0.1"
+
+      assert AmqpClient.init([queue: "queue", connection: connection]) ==
+               {:ok, "queue", %{connection: connection, qos: [prefetch_count: 50], requeue: :always}}
+    end
+
     test "unsupported options for Broadway" do
       assert AmqpClient.init(queue: "queue", option_1: 1, option_2: 2) ==
                {:error, "Unsupported options [:option_1, :option_2] for \"Broadway\""}

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -48,8 +48,9 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
     test "configure connection via uri" do
       connection = "amqp://guest:guest@127.0.0.1"
 
-      assert AmqpClient.init([queue: "queue", connection: connection]) ==
-               {:ok, "queue", %{connection: connection, qos: [prefetch_count: 50], requeue: :always}}
+      assert AmqpClient.init(queue: "queue", connection: connection) ==
+               {:ok, "queue",
+                %{connection: connection, qos: [prefetch_count: 50], requeue: :always}}
     end
 
     test "unsupported options for Broadway" do

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -50,7 +50,12 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
 
       assert AmqpClient.init(queue: "queue", connection: connection) ==
                {:ok, "queue",
-                %{connection: connection, qos: [prefetch_count: 50], requeue: :always}}
+                %{
+                  connection: connection,
+                  qos: [prefetch_count: 50],
+                  requeue: :always,
+                  metadata: []
+                }}
     end
 
     test "unsupported options for Broadway" do


### PR DESCRIPTION
Hi, 

Just wanted to say thank you for all the work on this and submit this pull-request to allow for binary uris that AMQP.connection.open supports. 

However this is just the start because this just shims in a pattern match to allow a pass through and doesn't do validation check. I can put that in but I thought I would ask your opinion on to achieve that. 

Right now, when it passes a uri, it does this 
https://github.com/pma/amqp/blob/master/lib/amqp/connection.ex#L105-L110

Already and this does a validation check that splits up the uri to do_open that looks a little like this. 

```elixir
"amqp://guest:guest@localhost/?heartbeat=27" |> String.to_charlist |> :amqp_uri.parse
{:ok,
 {:amqp_params_network, "guest", "guest", "", 'localhost', :undefined, 2047, 0,
  27, 60000, :none,
  [#Function<12.131604370/3 in :amqp_uri.mechanisms/1>,
   #Function<12.131604370/3 in :amqp_uri.mechanisms/1>], [], []}}
```

But if you feed it a bad key it just dumps it silently. Would it be prudent to put a check in that captures bad keys and return am error tuple with somewhat useful information?  