### PR TITLE
Allow passing RabbitMQ connection options via an AMQP URI

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -144,6 +144,13 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     |> validate_supported_opts(group, supported)
   end
 
+  defp validate_supported_opts(uri, :connection, _) when is_binary(uri) do
+    case uri |> to_charlist |> :amqp_uri.parse() do
+      {:ok, _amqp_params} -> {:ok, uri}
+      {:error, reason} -> {:error, "Failed parsing AMQP URI: #{inspect(reason)}"}
+    end
+  end
+
   defp validate_supported_opts(opts, group_name, supported_opts) do
     opts
     |> Keyword.keys()

--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -10,8 +10,8 @@ defmodule BroadwayRabbitMQ.Producer do
   ## Options
 
     * `:queue` - Required. The name of the queue.
-    * `:connection` - Optional. Defines a set of options used by the RabbitMQ
-      client to open the connection with the RabbitMQ broker. See
+    * `:connection` - Optional. Defines an AMQP URI or a set of options used by
+      the RabbitMQ client to open the connection with the RabbitMQ broker. See
       `AMQP.Connection.open/1` for the full list of options.
     * `:qos` - Optional. Defines a set of prefetch options used by the RabbitMQ client.
       See `AMQP.Basic.qos/2` for the full list of options. Pay attention that the

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -45,6 +45,18 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                 %{connection: connection, qos: qos, requeue: :once, metadata: metadata}}
     end
 
+    test "providing connection via a URI" do
+      connection = "amqp://guest:guest@127.0.0.1"
+
+      assert {:ok, "queue", %{connection: ^connection}} =
+               AmqpClient.init(queue: "queue", connection: connection)
+    end
+
+    test "invalid URI" do
+      assert {:error, "Failed parsing AMQP URI: " <> _} =
+               AmqpClient.init(queue: "queue", connection: "http://example.com")
+    end
+
     test "unsupported options for Broadway" do
       assert AmqpClient.init(queue: "queue", option_1: 1, option_2: 2) ==
                {:error, "Unsupported options [:option_1, :option_2] for \"Broadway\""}


### PR DESCRIPTION
This is a continuation @polymetis's work from #18. I opened a new PR in hope that this could be part of a new release.