### PR TITLE
Add metadata in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ Configure Broadway with one or more producers using `BroadwayRabbitMQ.Producer`:
   end
 ```
 
+### Metadata
+
+Use the `metadata` option with a list of atoms of the attributes we want to retrieve from AMQP producer:
+
+```elixir
+Broadway.start_link(MyBroadway,
+  name: MyBroadway,
+  producers: [
+    default: [
+      module: {BroadwayRabbitMQ.Producer,
+        queue: "my_queue",
+        metadata: [
+          :routing_key,
+          :redelivered,
+          :headers
+        ]
+      }
+    ]
+  ]
+)
+```
+
 ## License
 
 Copyright 2019 Plataformatec


### PR DESCRIPTION
I've updated the readme with information and a simple example of the new `metadata` parameter.