### PR TITLE
Add handling for unexpected connection close

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -324,6 +324,9 @@ defmodule BroadwayRabbitMQ.Producer do
       {:error, {:auth_failure, 'Disconnected'}} ->
         handle_backoff(state)
 
+      {:error, {:socket_closed_unexpectedly, :"connection.start"}} ->
+        handle_backoff(state)
+
       {:error, :econnrefused} ->
         handle_backoff(state)
     end


### PR DESCRIPTION
The error appears when RabbitMQ connection goes down in runtime after the application was successfully started. Without handling it will crash the supervisor it's linked to