### PR TITLE
fix: Handles an unknown host error

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -329,6 +329,9 @@ defmodule BroadwayRabbitMQ.Producer do
 
       {:error, :econnrefused} ->
         handle_backoff(state)
+
+      {:error, :unknown_host} ->
+        handle_backoff(state)
     end
   end
 


### PR DESCRIPTION
Got this error this morning. I don't know if there is a better way to handle this.