### PR TITLE
Sync queue options with amqp allowed opts

### DIFF
--- a/lib/broadway_rabbitmq/amqp_client.ex
+++ b/lib/broadway_rabbitmq/amqp_client.ex
@@ -180,7 +180,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
         {:ok, nil}
 
       {:ok, declare_opts} ->
-        supported = [:durable, :auto_delete, :exclusive, :passive]
+        supported = [:durable, :auto_delete, :exclusive, :passive, :no_wait, :arguments]
         validate_supported_opts(declare_opts, :declare, supported)
     end
   end
@@ -189,7 +189,7 @@ defmodule BroadwayRabbitMQ.AmqpClient do
     with {:ok, bindings} <- validate(opts, :bindings, _default = []) do
       Enum.reduce_while(bindings, {:ok, bindings}, fn
         {exchange, binding_opts}, acc when is_binary(exchange) ->
-          supported = [:routing_key, :nowait, :arguments]
+          supported = [:routing_key, :no_wait, :arguments]
 
           case validate_supported_opts(binding_opts, :bindings, supported) do
             {:ok, _bindings_opts} -> {:cont, acc}

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -144,8 +144,8 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
     end
 
     test ":bindings should be a list of tuples" do
-      {:ok, opts} = AmqpClient.init(queue: "queue", bindings: [{"my-exchange", [nowait: true]}])
-      assert opts[:bindings] == [{"my-exchange", [nowait: true]}]
+      {:ok, opts} = AmqpClient.init(queue: "queue", bindings: [{"my-exchange", [no_wait: true]}])
+      assert opts[:bindings] == [{"my-exchange", [no_wait: true]}]
 
       assert AmqpClient.init(queue: "queue", bindings: [:something, :else]) ==
                {:error,


### PR DESCRIPTION
The `:no_wait` and `:arguments` options for the `declare/4` function are allowed by the amqp library, however, they were not exposed in the documentation until [recently][1].

I've also changed the validation on `:nowait` binding opts to `:no_wait`,
as that one looks to be the correct (and documented) one.

[1]: https://github.com/pma/amqp/commit/ff19505d7fbd61839a7c17f12ae1758961f87e8e