### PR TITLE
Add support for a function as the :connection

### DIFF
--- a/lib/broadway_rabbitmq/producer.ex
+++ b/lib/broadway_rabbitmq/producer.ex
@@ -14,7 +14,13 @@ defmodule BroadwayRabbitMQ.Producer do
       the queue through the `:declare` option.
     * `:connection` - Optional. Defines an AMQP URI or a set of options used by
       the RabbitMQ client to open the connection with the RabbitMQ broker. See
-      `AMQP.Connection.open/1` for the full list of options.
+      `AMQP.Connection.open/1` for the full list of options. Other than a string
+      (URI) or keyword list of options, this option can also be set to a function
+      that takes one argument. This function will be called with the index of
+      the producer in the Broadway topology and must return a URI or keyword
+      list of options that is then passed to `AMQP.Connection.open/1`. This
+      is useful to connect producers to different RabbitMQ nodes, for example
+      through partitioning.
     * `:qos` - Optional. Defines a set of prefetch options used by the RabbitMQ client.
       See `AMQP.Basic.qos/2` for the full list of options. Pay attention that the
       `:global` option is not supported by Broadway since each producer holds only one

--- a/test/broadway_rabbitmq/ampq_client_test.exs
+++ b/test/broadway_rabbitmq/ampq_client_test.exs
@@ -72,6 +72,20 @@ defmodule BroadwayRabbitMQ.AmqpClientTest do
                AmqpClient.init(queue: "queue", connection: "http://example.com")
     end
 
+    test "providing a connection via a function that returns a URI" do
+      connection_fun = fn index -> "amqp://guest#{index}:guest@127.0.0.1" end
+
+      assert {:ok, %{connection: "amqp://guest1:guest@127.0.0.1"}} =
+               AmqpClient.init(queue: "queue", connection: connection_fun, broadway_index: 1)
+    end
+
+    test "providing a connection via a function that returns a keyword list of options" do
+      connection_fun = fn index -> [username: "guest#{index}"] end
+
+      assert {:ok, %{connection: [username: "guest4"]}} =
+               AmqpClient.init(queue: "queue", connection: connection_fun, broadway_index: 4)
+    end
+
     test "unsupported options for Broadway" do
       assert AmqpClient.init(queue: "queue", option_1: 1, option_2: 2) ==
                {:error, "Unsupported options [:option_1, :option_2] for \"Broadway\""}


### PR DESCRIPTION
Closes #36.

This allows us to do something like:

```elixir
urls = [
  "amqp://127.0.0.1",
  "amqp://127.0.0.2"
]

{BroadwayRabbitMQ.Producer, connection: &Enum.at(urls, rem(&1, 2))}
```

**Note**: for this to work, Broadway master is required (as support for `:broadway_index` was introduced in https://github.com/plataformatec/broadway/pull/113.

\cc @msaraiva @josevalim 